### PR TITLE
Player collision stun

### DIFF
--- a/common/physics.world.ts
+++ b/common/physics.world.ts
@@ -63,6 +63,12 @@ const HIT_KNOCKBACK_MULTIPLIER = 0.1;
 const STAGGER_PER_DAMAGE = 0.003;
 
 /**
+ * Player collision damage is scaled down by PLAYER_MASS_SCALE; scale stagger
+ * back up so body-to-body hits still reduce control.
+ */
+const PLAYER_COLLISION_STAGGER_MULTIPLIER = PLAYER_MASS_SCALE;
+
+/**
  * How fast `controlReduction` decays back to 0, in units per second.
  * 1.0 means a 50% stagger recovers in 0.5 s.
  */
@@ -420,12 +426,21 @@ export function stepPhysics(physicsWorld: PhysicsWorld, room: Room, elapsedTime:
   // Apply stagger from the damage dealt this tick
   for (const damage of damages) {
     const damagedPlayer = room.players[damage.damagedPlayerId];
-    if (damagedPlayer) {
-      damagedPlayer.controlReduction = Math.min(
-        1,
-        damagedPlayer.controlReduction + damage.amount * STAGGER_PER_DAMAGE,
-      );
+    if (!damagedPlayer) {
+      continue;
     }
+
+    if (damage.type === "playerCollision" && damagedPlayer.weapon.type === "aura") {
+      continue;
+    }
+
+    const staggerMultiplier =
+      damage.type === "playerCollision" ? PLAYER_COLLISION_STAGGER_MULTIPLIER : 1;
+
+    damagedPlayer.controlReduction = Math.min(
+      1,
+      damagedPlayer.controlReduction + damage.amount * STAGGER_PER_DAMAGE * staggerMultiplier,
+    );
   }
 
   // 6. Read final Rapier state into Room


### PR DESCRIPTION
Add stun/stagger for player-to-player collisions.

Player collision damage is scaled down, so the stagger is scaled back up to ensure body-to-body impacts noticeably reduce control. Players with aura weapons are made immune to collision stagger, aligning with existing aura immunity.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f6abdace-4ff8-402a-a4e5-759bf23299ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6abdace-4ff8-402a-a4e5-759bf23299ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized tuning change to stagger application in the physics tick; main risk is gameplay balance/feel regressions rather than correctness or security.
> 
> **Overview**
> Adds collision-based stagger: `controlReduction` now increases from `playerCollision` damage as well as weapon damage, with a new multiplier to compensate for player-collision damage being scaled down by `PLAYER_MASS_SCALE`.
> 
> Players using an `aura` weapon are made immune to collision stagger (while still taking other stagger), aligning collision behavior with existing aura-related immunity expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59b6eace1285e5029f55af4c431ac8cafcd063c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->